### PR TITLE
Removed Error Causing JS Function for Current Year (Called but unused)

### DIFF
--- a/conquestofbread.html
+++ b/conquestofbread.html
@@ -7543,12 +7543,4 @@ opened up by the Social Revolution.</p>
             </footer>
 </div>
 </body>
-<script>
-function yearFunction() {
-var d = new Date();
-var fullYear = d.getFullYear();
-document.getElementById('copy-year').innerHTML = fullYear;
-}
-yearFunction();
-</script>
 </html>

--- a/downloads.html
+++ b/downloads.html
@@ -196,12 +196,4 @@
             </footer>
 </div>
 </body>
-<script>
-function yearFunction() {
-var d = new Date();
-var fullYear = d.getFullYear();
-document.getElementById('copy-year').innerHTML = fullYear;
-}
-yearFunction();
-</script>
 </html>

--- a/index.html
+++ b/index.html
@@ -239,12 +239,4 @@ and build a different and better world. </p>
             </footer>
 </div>
 </body>
-<script>
-function yearFunction() {
-var d = new Date();
-var fullYear = d.getFullYear();
-document.getElementById('copy-year').innerHTML = fullYear;
-}
-yearFunction();
-</script>
 </html>

--- a/resources.html
+++ b/resources.html
@@ -146,12 +146,4 @@
             </footer>
 </div>
 </body>
-<script>
-function yearFunction() {
-var d = new Date();
-var fullYear = d.getFullYear();
-document.getElementById('copy-year').innerHTML = fullYear;
-}
-yearFunction();
-</script>
 </html>


### PR DESCRIPTION
I noticed a JavaScript function to write the current year to a missing HTML element. Since the element isn't there, I removed this function. 

If people were to want the current year written to the page it would make sense to add a similar function back into a shared JavaScript file instead of having it on each page. 

Additionally, it might make sense to leverage a static site generator ([such as Jekyll which integrates with GitHub pages](https://jekyllrb.com/docs/github-pages/)) to write that in so that we don't have to rely on visitors to the site having JavaScript enabled.