### PR TITLE
Exclude Project Files from the Generated Site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Linux backup files
 *~
+# jekyll _site directory
+_site/

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+exclude:
+  - ".gitignore"
+  - "info.txt"


### PR DESCRIPTION
GitHub pages uses [Jekyll](https://jekyllrb.com/) to build sites, by introducing a config file for Jekyll `_config.yml` we can exclude files from the repository from being deployed to the website. 

Currently visitors to the https://thebreadbook.org can visit:
* https://thebreadbook.org/info.txt
* https://thebreadbook.org/.gitignore

Neither of these files are really intended for visitors to the site, and there's no reason for them to be indexed by scrapers/search engines/etc. I wonder if info.txt even needs to be in the repository anymore. 

Jekyll might have a lot of other benefits for this project, but as a build tool all of its features are very optional and shouldn't change anyone's workflow on this project. If you generate the site using jekyll locally, a `_site` directory gets created in the root directory of the repository. I've added a line  to the `.gitignore` to prevent anyone from accidentally checking it in. 